### PR TITLE
feat: add WiFi signal strength sensor

### DIFF
--- a/custom_components/cloudplus/sensor.py
+++ b/custom_components/cloudplus/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import CloudEdgeMeariCoordinator
 from .entity import CloudEdgeMeariEntity, CloudEdgeMeariIotNumericEntity
-from .meari_commands import HUMIDITY, TEMPERATURE
+from .meari_commands import HUMIDITY, TEMPERATURE, WIFI_STRENGTH
 
 # (min percent, icon) ladders, highest threshold first.
 _CHARGING_BATTERY_ICONS = (
@@ -68,6 +68,14 @@ IOT_SENSORS: tuple[IotSensorSpec, ...] = (
         "Humidity",
         SensorDeviceClass.HUMIDITY,
         PERCENTAGE,
+    ),
+    IotSensorSpec(
+        "wifi_signal",
+        WIFI_STRENGTH,
+        "WiFi Signal",
+        None,
+        PERCENTAGE,
+        icon="mdi:wifi",
     ),
 )
 


### PR DESCRIPTION
## Summary
- Adds a `sensor` entity for IoT code `1007` (WiFi signal strength, 0-100 scale) using the existing `IotSensorSpec` declarative pattern (same as temperature/humidity).
- No new API calls needed: code `1007` is already part of `BATTERY_CODES`, so it's fetched on every battery poll — it just wasn't surfaced as an entity yet.

## Motivation
Useful for battery/solar cameras placed outdoors, where WiFi signal quality can vary a lot with placement and weather, and is worth monitoring/alerting on in HA.

## Test plan
- Verified against a real battery camera (iegeek app profile) after relocating it outdoors: the sensor appears and reports a sane 0-100 value that updates on the normal battery poll cycle.
- No changes to existing entities/behavior.